### PR TITLE
Support long object keys via metaInfo field in registration

### DIFF
--- a/src/plugins/obj/obj_backend.h
+++ b/src/plugins/obj/obj_backend.h
@@ -21,6 +21,7 @@
 #include "obj_executor.h"
 #include <string>
 #include <memory>
+#include <unordered_map>
 #include <aws/core/Aws.h>
 #include <aws/core/client/ClientConfiguration.h>
 #include <aws/core/auth/AWSCredentials.h>
@@ -101,6 +102,7 @@ private:
     std::unique_ptr<Aws::SDKOptions, void(*)(Aws::SDKOptions*)> aws_options_;
     std::unique_ptr<Aws::S3::S3Client> s3_client_;
     std::string bucket_name_;
+    std::unordered_map<uint64_t, std::string> dev_id_to_obj_key;
 };
 
 #endif // OBJ_BACKEND_H


### PR DESCRIPTION
Extended OBJ key handling by enabling support for long keys beyond the 64-bit devID limit. 
Objects are now registered with short 64-bit devIDs, while the full key is passed in the metaInfo field. 
Backends store the long key in nixlBackendMD associated with the devID, enabling transparent use 
of short keys during transfers. Fallback to devID-as-key supported when metaInfo is empty.